### PR TITLE
Proposed CSS change to allow full-width <li/> for speaker with long bio.

### DIFF
--- a/_assets/css/layouts/_event-2019.scss
+++ b/_assets/css/layouts/_event-2019.scss
@@ -131,6 +131,10 @@
                 &:nth-last-of-type(n + 3) {
                     padding-bottom: 20px;
                 }
+                &.full-width {
+                    width: 100%;
+                    padding-bottom: 20px;
+                }
             }
 
             @media screen and (max-width: 768px) {

--- a/_layouts/event-2019.html
+++ b/_layouts/event-2019.html
@@ -130,7 +130,11 @@ sitemap:
             {% assign speaker_info = speaker_hash[1] %}
             {% assign speaker_profile = site.speakers | where: 'slug', speaker_slug | first %}
             {% if speaker_profile %}
+            {% if speaker_profile.bio.size > 100 %}
+            <li class="full-width">
+            {% else %}
             <li>
+            {% endif %}>}
                 <a class="speaker-link" href="{{ speaker_profile.url }}" data-click-category="discovery" data-click-action="speaker_link" data-click-label="{{ speaker_profile.title }}">
                 <figure class="speaker-item">
                     <img data-proofer-ignore data-lazy-src="{% if speaker_profile.image %}{{ speaker_profile.image }}{% else %}/assets/images/speakers/anonymous.png{% endif %}" alt="{{ speaker_profile.title }}" class="speaker">


### PR DESCRIPTION
Hey - not 100% convinced about this one... options are merge it, ignore it, or don't allow any speakers to have a bio > 100 characters?

I'm not keen on option (3) 'cos I think Louise Paling's bio is genuinely funny BECAUSE it's so long... and I don't much like the way it breaks the layout, so figured a full-width LI was probably the most elegant solution. But open to suggestions if you got a better idea?