### PR TITLE
Vertically centers supporter logos; uses 100% width on < 480px devices.

### DIFF
--- a/_assets/css/layouts/_event-2019.scss
+++ b/_assets/css/layouts/_event-2019.scss
@@ -324,10 +324,14 @@
             display: flex;
             justify-content: space-around;
             flex-wrap: wrap;
+            align-items: center;
             li {
                 flex: 0 0 33%;
                 @media screen and (max-width: 768px) {
                     flex: 0 0 50%;
+                }
+                @media screen and (max-width: 480px) {
+                    flex: 0 0 100%;
                 }
                 a {
                     display: block;


### PR DESCRIPTION
Hey. Couple of proposed tweaks to the supporter CSS - one vertically aligns logos on wider screens so they're center-aligned; the other drops to a single-column (100%) layout on screens < 480px - made the Notts screen look a little cleaner with more logos on smaller devices. 