### PR TITLE
Lock jekyll-assets plugin to 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "github-pages", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-    gem "jekyll-assets"
+    gem "jekyll-assets", "~> 2.3.2"
     gem "jekyll-redirect-from"
 end
 


### PR DESCRIPTION
Some serious weirdness with `jekyll-assets` - my best guess is that for some reason it didn't pick up the release of 3.x until now, even though it's been out for nearly two years? The PubConf pages all use the 2.x tags and syntax (and locking the plugin version back to 2.x makes it all work again)

I got no idea.